### PR TITLE
Add environment scripts and lint helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ flowchart TD
 - Multiple MCP servers for GitHub, browser automation, git operations
 - File management and code analysis tools
 - Web fetching and search capabilities
+## Utility Scripts
+- `scripts/env-info.sh` detects runtime details such as container status and OS information.
+- `scripts/markdownlint.sh` runs markdownlint via `npx` to enforce consistent Markdown style.
+See [scripts/README.md](scripts/README.md) for more details.
 
 ## Project Status
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -16,6 +16,7 @@
 2. Update .clinerules with Memory Bank usage patterns and project intelligence
 3. Verify all cross-references between Memory Bank files are accurate
 4. Ensure templates are fully self-instructive for any AI agent
+5. Add environment detection and markdown lint scripts for CI/CD readiness
 
 ## Recent Changes
 
@@ -28,6 +29,9 @@
 - `memory-bank/progress.md` - Project evolution and status template
 - `.clinerules` - Enhanced with Memory Bank implementation patterns
 - `README.md` - Comprehensive project overview and usage guidelines
+- `scripts/README.md` - Descriptions for environment and lint scripts
+- `scripts/env-info.sh` - Environment detection utility
+- `scripts/markdownlint.sh` - Markdown linting helper
 
 **Key Decisions Made:**
 - Memory Bank structure follows hierarchical dependency model (projectbrief → others → activeContext → progress)
@@ -80,6 +84,7 @@
 - All files follow self-instructive design principles
 - Templates ready for any AI agent to use immediately
 - Project intelligence patterns documented in .clinerules
+- Initial environment detection and markdown lint scripts added for CI/CD readiness
 - Comprehensive README provides clear onboarding and usage instructions
 - System ready for real-world project implementation
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -24,6 +24,7 @@
 - Comprehensive AI agent instruction sections in all files
 - Enhanced .clinerules with project intelligence patterns
 - README.md with complete project overview and usage guidelines
+- Initial environment detection and markdown lint scripts for CI/CD
 - Full documentation system ready for real-world deployment
 
 **Validated Approaches:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,26 @@
+# Scripts Directory
+
+This folder contains utility scripts that help manage the project
+environment and code quality. Each script is designed to be lightweight
+and self-contained so it can be executed directly without additional
+dependencies beyond what is already expected for the project. Keeping
+these scripts small and well-documented ensures that any AI agent or human
+contributor can understand and run them with minimal setup.
+
+## env-info.sh
+
+`env-info.sh` gathers information about the current execution environment. It
+checks whether the project is running inside a container and extracts
+details such as the kernel version, base operating system, user, and
+working directory. This helps validate the runtime context during each
+lifecycle phase and is useful for troubleshooting or for CI/CD pipelines
+that need to capture environment metadata.
+
+## markdownlint.sh
+
+`markdownlint.sh` runs
+[markdownlint](https://github.com/DavidAnson/markdownlint) across specified
+Markdown files to enforce consistent style. The script invokes `markdownlint`
+via `npx` so it does not require a global installation. It is intended to
+be executed before commits or as part of automated quality checks to ensure
+all Markdown files in the repository adhere to project formatting rules.

--- a/scripts/env-info.sh
+++ b/scripts/env-info.sh
@@ -3,6 +3,7 @@
 # Usage: ./env-info.sh
 
 set -e
+set -o pipefail
 
 is_container() {
     if [ -f /.dockerenv ]; then

--- a/scripts/env-info.sh
+++ b/scripts/env-info.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# env-info.sh - Detect basic environment information
+# Usage: ./env-info.sh
+
+set -e
+
+is_container() {
+    if [ -f /.dockerenv ]; then
+        return 0
+    fi
+    if grep -qE '(docker|lxc|containerd)' /proc/1/cgroup 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+BASE_OS="$(uname -s)"
+OS_RELEASE=""
+if [ -f /etc/os-release ]; then
+    OS_RELEASE="$(. /etc/os-release && echo "$NAME $VERSION")"
+fi
+
+if is_container; then
+    CONTAINER_STATUS="inside-container"
+else
+    CONTAINER_STATUS="host-machine"
+fi
+
+cat <<INFO
+Container Status: $CONTAINER_STATUS
+Kernel: $(uname -r)
+Base OS: $BASE_OS
+OS Release: ${OS_RELEASE:-unknown}
+User: $(whoami)
+Home Dir: $HOME
+PWD: $(pwd)
+INFO
+
+

--- a/scripts/markdownlint.sh
+++ b/scripts/markdownlint.sh
@@ -3,7 +3,7 @@
 # Usage: ./markdownlint.sh [files]
 
 set -e
-
+set -o pipefail
 if ! command -v npx >/dev/null 2>&1; then
   echo "npx is required but not installed" >&2
   exit 1

--- a/scripts/markdownlint.sh
+++ b/scripts/markdownlint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# markdownlint.sh - Lint Markdown files using markdownlint
+# Usage: ./markdownlint.sh [files]
+
+set -e
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "npx is required but not installed" >&2
+  exit 1
+fi
+
+npx markdownlint "$@"
+


### PR DESCRIPTION
## Summary
- add simple environment detection utility
- add markdownlint helper script and document them
- mention new scripts in README
- log new tasks in `activeContext.md` and `progress.md`

## Testing
- `./scripts/env-info.sh`
- `./scripts/markdownlint.sh scripts/README.md`
- `./scripts/markdownlint.sh README.md` *(fails: various markdownlint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841f78ae17083318d6a5c1ab2b69467